### PR TITLE
rosrun: Do not offer executables under CATKIN_IGNORE

### DIFF
--- a/tools/rosbash/scripts/rosrun
+++ b/tools/rosbash/scripts/rosrun
@@ -14,6 +14,16 @@ function debug() {
   return
 }
 
+function parent_find() {
+  local file="$1"
+  local dir="$2"
+
+  test -e "$dir/$file" && readlink -f "$dir" && return 0
+  [ '/' = "$dir" ] && return 1
+
+  parent-find "$file" "$(readlink -f "$dir/..")"
+}
+
 while [ $args == 1 ]
 do
   case "$1" in
@@ -88,13 +98,17 @@ if [[ ! $file_name == */* ]]; then
     _perm="/111"
   fi
   debug "Searching for $file_name with permissions $_perm"
-  exepathlist="$(find -L "${catkin_package_libexec_dirs[@]}" "$pkgdir" -name "$file_name" -type f  -perm "$_perm" ! -regex ".*$pkgdir\/build\/.*" | uniq)"
+  exepathlist="$(find -L "${catkin_package_libexec_dirs[@]}" "$pkgdir" -name "$file_name" -type f  -perm "$_perm" ! -regex ".*$pkgdir\/build\/.*" | sort -u)"
   _rosrun_IFS="$IFS"
   IFS=$'\n'
   exepathlist=($exepathlist)
   IFS="$_rosrun_IFS"
   unset _rosrun_IFS
   unset _perm
+  for index in "${!exepathlist[@]}"; do
+    parent_find CATKIN_IGNORE "$(dirname "${exepathlist[$index]}")" 1>/dev/null 2>/dev/null && debug "Excluding ${exepathlist[$index]} due to CATKIN_IGNORE" && unset -v 'exepathlist[$index]';
+  done
+  exepathlist=("${exepathlist[@]}")
   if [[ ${#exepathlist[@]} == 0 ]]; then
     echo "[rosrun] Couldn't find executable named $file_name below $pkgdir"
     nonexepathlist=($(find -H "$pkgdir" -name "$file_name"))


### PR DESCRIPTION
Some IDEs (CLion) create build directories under package source folders whose name is not `build` (CLion makes `cmake-build-debug` etc.). These directories are properly initialized with catkin, so a `CATKIN_IGNORE` is put into them. However, `rosrun` still finds executables in these folders and in case of Python scripts, this results in a non-unique file to be run, which in turn results in the need of user input, which in turn makes it impossible to run these executables from launch files.

This PR fixes it and no executables under an ignored directory are considered.

However, I'm not sure if running ignored executables is not actually a valid use-case. If so, could the solution be that this pruning is only done in case there is exactly one non-ignored and one or more ignored executables?